### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#b185d5c` to `dev-main#53d9149`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3256,12 +3256,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "b185d5c16e7c91d4bbf731d1118adc77960d873e"
+                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b185d5c16e7c91d4bbf731d1118adc77960d873e",
-                "reference": "b185d5c16e7c91d4bbf731d1118adc77960d873e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/53d9149014e9e11ff0eb23220e21546686bbfc86",
+                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86",
                 "shasum": ""
             },
             "require": {
@@ -3310,7 +3310,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.6",
+                "phpunit/phpunit": "~12.3.7",
                 "symfony/var-dumper": "~7.3.2",
                 "vimeo/psalm": "~6.13.1"
             },
@@ -3418,7 +3418,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-26T14:13:05+00:00"
+            "time": "2025-08-28T09:41:39+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#b185d5c` to `dev-main#53d9149`.

This pull request changes the following file(s): 

- Update `composer.lock`