### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#3cf3a30`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,13 +66,6 @@
             "Ghostwriter\\Nixify\\": "src"
         }
     },
-    "extra": {
-        "ghostwriter": {
-            "container": {
-                "provider": "Ghostwriter\\Nixify\\Container\\NixifyServiceProvider"
-            }
-        }
-    },
     "autoload-dev": {
         "psr-4": {
             "Tests\\Unit\\": "tests/Unit/"
@@ -102,6 +95,13 @@
         "process-timeout": 5000,
         "sort-packages": true,
         "use-parent-dir": false
+    },
+    "extra": {
+        "ghostwriter": {
+            "container": {
+                "provider": "Ghostwriter\\Nixify\\Container\\NixifyServiceProvider"
+            }
+        }
     },
     "scripts": {
         "cache:clear": "rm -rf ./.cache/*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c2eaeaf7fe4f2cffbc2fde1f259e50b",
+    "content-hash": "6ed96abc7c6bcc0fc5a438b9b8e0d3ff",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -2150,12 +2150,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "4393c6a3c587cca72fec22db70bae49727bd2f7d"
+                "reference": "3cf3a302be08591722b5f2f550821172d128e517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4393c6a3c587cca72fec22db70bae49727bd2f7d",
-                "reference": "4393c6a3c587cca72fec22db70bae49727bd2f7d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/3cf3a302be08591722b5f2f550821172d128e517",
+                "reference": "3cf3a302be08591722b5f2f550821172d128e517",
                 "shasum": ""
             },
             "require": {
@@ -2311,7 +2311,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-03T06:49:21+00:00"
+            "time": "2025-09-06T11:50:21+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#4393c6a` to `dev-main#3cf3a30`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`