### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#309e2d1`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2150,12 +2150,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db"
+                "reference": "309e2d19e5c2feee60360e6425162199d02a3d7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b41b8c9261587c68541e6bf38933426ce8b9c8db",
-                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/309e2d19e5c2feee60360e6425162199d02a3d7f",
+                "reference": "309e2d19e5c2feee60360e6425162199d02a3d7f",
                 "shasum": ""
             },
             "require": {
@@ -2312,7 +2312,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T17:06:16+00:00"
+            "time": "2025-09-11T18:08:28+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#b41b8c9` to `dev-main#309e2d1`.

This pull request changes the following file(s): 

- Update `composer.lock`