### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ea2be7c

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2150,12 +2150,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ea2be7cf71be411d7350ff61c003867453992ba0",
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0",
                 "shasum": ""
             },
             "require": {
@@ -2312,7 +2312,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T14:31:25+00:00"
+            "time": "2025-09-21T15:43:42+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#62def0c` to `dev-main#ea2be7c`.

This pull request changes the following file(s): 

- Update `composer.lock`