### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ca8d6f7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1918,156 +1918,20 @@
     ],
     "packages-dev": [
         {
-            "name": "boundwize/structarmed",
-            "version": "0.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "313a9d05146755160a10ad6c0b82393cb91abaeb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/313a9d05146755160a10ad6c0b82393cb91abaeb",
-                "reference": "313a9d05146755160a10ad6c0b82393cb91abaeb",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.0",
-                "fidry/cpu-core-counter": "^1.3",
-                "nikic/php-parser": "^5.7",
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^3.1",
-                "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^11.5",
-                "rector/rector": "dev-main"
-            },
-            "bin": [
-                "bin/structarmed"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Boundwize\\StructArmed\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Abdul Malik Ikhsan",
-                    "email": "samsonasik@gmail.com",
-                    "homepage": "http://samsonasik.wordpress.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Configurable PHP architecture guards — define your layers and rules, then keep them enforced",
-            "homepage": "https://github.com/boundwize/structarmed",
-            "keywords": [
-                "Enforcement",
-                "analysis",
-                "architecture",
-                "ddd",
-                "dev",
-                "layer",
-                "mvc",
-                "psr1",
-                "psr12",
-                "psr15",
-                "psr4"
-            ],
-            "support": {
-                "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.8.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/samsonasik",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-05-27T10:31:50+00:00"
-        },
-        {
-            "name": "fidry/cpu-core-counter",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "fidry/makefile": "^0.2.0",
-                "fidry/php-cs-fixer-config": "^1.1.2",
-                "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-deprecation-rules": "^2.0.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
-                "webmozarts/strict-phpunit": "^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Fidry\\CpuCoreCounter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Théo FIDRY",
-                    "email": "theo.fidry@gmail.com"
-                }
-            ],
-            "description": "Tiny utility to get the number of CPU cores.",
-            "keywords": [
-                "CPU",
-                "core"
-            ],
-            "support": {
-                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theofidry",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-14T07:29:31+00:00"
-        },
-        {
             "name": "ghostwriter/coding-standard",
             "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "262e6b44d83cf8909f24b85a3e1b1bc93435e492"
+                "reference": "ca8d6f740a7cd548808ae69f7b5fa4550caeb871"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/262e6b44d83cf8909f24b85a3e1b1bc93435e492",
-                "reference": "262e6b44d83cf8909f24b85a3e1b1bc93435e492",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ca8d6f740a7cd548808ae69f7b5fa4550caeb871",
+                "reference": "ca8d6f740a7cd548808ae69f7b5fa4550caeb871",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.8.0",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -2113,10 +1977,7 @@
                 "ext-zend-opcache": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
-                "mockery/mockery": "^1.6.12",
-                "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.13",
-                "symfony/var-dumper": "^8.0.8"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -2178,7 +2039,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-27T14:24:53+00:00"
+            "time": "2026-05-27T19:35:28+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#262e6b4` to `dev-main#ca8d6f7`.

This pull request changes the following file(s): 

- Update `composer.lock`